### PR TITLE
Show Turnstile only on upload click, harden upload backend

### DIFF
--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -7,8 +7,10 @@ import { toBlobURL } from "@ffmpeg/util";
 import { FileData, formatBytes, removeExifData, EXIF_REMOVABLE_TYPES } from "@/lib/utils";
 import { ConvertToGif } from "@/lib/gifConvert";
 import { toast } from "sonner";
-import { useAction, useConvexAuth, useQuery } from "convex/react";
+import { useConvexAuth, useMutation, useQuery } from "convex/react";
+import { useAuth } from "@clerk/nextjs";
 import { api } from "@/convex/_generated/api";
+import { Id } from "@/convex/_generated/dataModel";
 import { Turnstile, TurnstileInstance, TurnstileProps } from "@marsidev/react-turnstile";
 
 function ChevronIcon({ isOpen }: { isOpen: boolean }) {
@@ -36,7 +38,8 @@ const GIF_CONVERTIBLE_TYPES = new Set([
 
 export function FileUpload() {
   const { isAuthenticated } = useConvexAuth();
-  const getUploadUrl = useAction(api.files.getUploadUrl);
+  const { getToken } = useAuth();
+  const confirmUpload = useMutation(api.files.confirmUpload);
   const getMaxSize = useQuery(api.files.getMaxSize);
 
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
@@ -50,6 +53,8 @@ export function FileUpload() {
   const [saveToAccount, setSaveToAccount] = useState(false);
   const [optionsOpen, setOptionsOpen] = useState(false);
   const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
+  const [showTurnstile, setShowTurnstile] = useState(false);
+  const pendingUploadRef = useRef(false);
 
   const [uploadSpeed, setUploadSpeed] = useState("");
   const [uploadEta, setUploadEta] = useState("");
@@ -154,12 +159,30 @@ export function FileUpload() {
     }
   };
 
-  const handleUpload = async () => {
-    if (!turnstileToken) {
-      toast.error("Please complete the verification");
+  const handleUpload = () => {
+    if (!selectedFile) {
       return;
     }
 
+    if (!turnstileToken) {
+      // Show the widget and run the upload once verification succeeds
+      pendingUploadRef.current = true;
+      setShowTurnstile(true);
+      return;
+    }
+
+    performUpload(turnstileToken);
+  };
+
+  const handleTurnstileSuccess = (token: string) => {
+    setTurnstileToken(token);
+    if (pendingUploadRef.current) {
+      pendingUploadRef.current = false;
+      performUpload(token);
+    }
+  };
+
+  const performUpload = async (token: string) => {
     if (!selectedFile) {
       return;
     }
@@ -188,16 +211,41 @@ export function FileUpload() {
       save: saveToAccount && isAuthenticated
     });
 
-    const { url: uploadUrl } = await getUploadUrl({
-      ...fileData,
-      turnstileToken
-    }).catch((e) => {
-      console.error(e);
-      return { url: "" };
-    });
+    // Presign goes through a Convex HTTP action (not a plain action) so the
+    // server can rate-limit anonymous users by their real IP.
+    const convexSiteUrl = process.env.NEXT_PUBLIC_CONVEX_URL!.replace(
+      ".convex.cloud",
+      ".convex.site"
+    );
+    const authToken = isAuthenticated
+      ? await getToken({ template: "convex" }).catch(() => null)
+      : null;
+
+    const { url: uploadUrl, fileId } = (await fetch(
+      `${convexSiteUrl}/getUploadUrl`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(authToken ? { Authorization: `Bearer ${authToken}` } : {})
+        },
+        body: JSON.stringify({ ...fileData, turnstileToken: token })
+      }
+    )
+      .then(async (res) => {
+        if (!res.ok) {
+          throw new Error((await res.json()).error ?? "Failed to get upload URL");
+        }
+        return res.json();
+      })
+      .catch((e) => {
+        console.error(e);
+        return { url: "", fileId: null };
+      })) as { url: string; fileId: Id<"files"> | null };
 
     turnstileRef.current?.reset();
     setTurnstileToken(null);
+    setShowTurnstile(false);
 
     if (uploadUrl === "") {
       setMessageProgress("Errored");
@@ -253,6 +301,10 @@ export function FileUpload() {
         return;
       }
       setMessageProgress("");
+      if (fileId) {
+        // Flip the pending DB row to confirmed now that the file exists
+        confirmUpload({ fileId }).catch(console.error);
+      }
       const url = new URL(uploadUrl);
       setUploadedUrl(
         `${process.env.NEXT_PUBLIC_DESTINATION_URL}${url.pathname}`
@@ -421,23 +473,25 @@ export function FileUpload() {
         </div>
       </div>
 
-      <div className="flex justify-center">
-        <Turnstile
-          ref={turnstileRef}
-          siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY!}
-          onSuccess={setTurnstileToken}
-          onError={() => setTurnstileToken(null)}
-          onExpire={() => setTurnstileToken(null)}
-          options={{
-            theme: "dark"
-          }}
-        />
-      </div>
+      {showTurnstile && (
+        <div className="flex justify-center">
+          <Turnstile
+            ref={turnstileRef}
+            siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY!}
+            onSuccess={handleTurnstileSuccess}
+            onError={() => setTurnstileToken(null)}
+            onExpire={() => setTurnstileToken(null)}
+            options={{
+              theme: "dark"
+            }}
+          />
+        </div>
+      )}
 
       <Button
         className="py-5 text-base sm:py-2 sm:text-sm"
         onClick={handleUpload}
-        disabled={!turnstileToken}
+        disabled={!selectedFile}
       >
         Upload
       </Button>

--- a/convex/files.ts
+++ b/convex/files.ts
@@ -1,12 +1,40 @@
-import { action, internalMutation, query } from "./_generated/server";
+import { internalAction, internalMutation, mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { internal } from "@/convex/_generated/api";
 import { getCurrentUser, getCurrentUserOrThrow } from "@/convex/users";
+import { Id } from "./_generated/dataModel";
 import { uploadRatelimit, verifyTurnstileToken } from "@/convex/ratelimit";
 
-const MAX_SIZE = 250000000;
+const DEFAULT_MAX_SIZE = 250000000;
+
+// Server-side guard — client-side zod can be bypassed by calling the API
+// directly. Strips path separators and control characters so the name can
+// never escape its `<random>/` prefix in the bucket.
+function sanitizeFileName(name: string): string {
+  const sanitized = Array.from(name)
+    .map((ch) => {
+      const code = ch.charCodeAt(0);
+      return ch === "/" || ch === "\\" || code < 32 || code === 127 ? "_" : ch;
+    })
+    .join("")
+    .trim();
+  if (
+    sanitized.length === 0 ||
+    sanitized.length > 256 ||
+    sanitized === "." ||
+    sanitized === ".."
+  ) {
+    throw new Error("Invalid file name");
+  }
+  return sanitized;
+}
+
+function getMaxUploadSize() {
+  const fromEnv = Number(process.env.MAX_SIZE);
+  return Number.isFinite(fromEnv) && fromEnv > 0 ? fromEnv : DEFAULT_MAX_SIZE;
+}
 
 function generateString(length: number) {
   let result = "";
@@ -26,7 +54,7 @@ function generateString(length: number) {
 export const getMaxSize = query({
   args: {},
   handler: () => {
-    return Number(process.env.MAX_SIZE) ?? MAX_SIZE;
+    return getMaxUploadSize();
   }
 });
 
@@ -38,19 +66,34 @@ export const getFiles = query({
       return [];
     }
 
-    return ctx.db.query("files").filter(row => row.eq(row.field("userId"), user._id)).collect();
+    return ctx.db
+      .query("files")
+      .withIndex("byUserId", q => q.eq("userId", user._id))
+      .filter(row => row.neq(row.field("pending"), true))
+      .collect();
   }
 });
 
-export const getUploadUrl = action({
+// Only callable from the /getUploadUrl HTTP action, which derives
+// `identifier` (user id or client IP) server-side so it can't be spoofed.
+export const getUploadUrl = internalAction({
   args: {
     name: v.string(),
     type: v.string(),
     size: v.number(),
     save: v.boolean(),
     turnstileToken: v.string(),
+    identifier: v.string(),
   },
-  handler: async (ctx, args) => {
+  handler: async (
+    ctx,
+    args
+  ): Promise<{ url: string; fileId: Id<"files"> | null }> => {
+    const fileName = sanitizeFileName(args.name);
+    if (args.type.length > 256) {
+      throw new Error("Invalid file type");
+    }
+
     const identity = await ctx.auth.getUserIdentity();
     if (!identity && args.save) {
       throw new Error("Saving a file to account without an account");
@@ -61,13 +104,16 @@ export const getUploadUrl = action({
       throw new Error("Bot verification failed. Please try again.");
     }
 
-    const identifier = identity?.subject ?? "anonymous";
-    const { success } = await uploadRatelimit.limit(identifier);
+    const { success } = await uploadRatelimit.limit(args.identifier);
     if (!success) {
       throw new Error("Rate limit exceeded. Please try again later.");
     }
 
-    if (args.size > (Number(process.env.MAX_SIZE) ?? MAX_SIZE)) {
+    if (!Number.isInteger(args.size) || args.size <= 0) {
+      throw new Error("Invalid file size");
+    }
+
+    if (args.size > getMaxUploadSize()) {
       throw new Error("File is too big");
     }
 
@@ -80,7 +126,7 @@ export const getUploadUrl = action({
         }
       });
 
-      const uploadPath = `${generateString(8)}/${args.name}`;
+      const uploadPath = `${generateString(8)}/${fileName}`;
 
       const command = new PutObjectCommand({
         Bucket: process.env.S3_BUCKET,
@@ -91,15 +137,25 @@ export const getUploadUrl = action({
 
       const shortUrl = await getSignedUrl(s3Client, command, { expiresIn: 900 });
 
+      let fileId: Id<"files"> | null = null;
       if (args.save) {
-        await ctx.runMutation(internal.files.saveFile, {
-          url: `${process.env.DESTINATION_URL}/${uploadPath}`,
+        // Insert a pending row now; the client confirms it after the PUT
+        // succeeds. If it never does, the scheduled cleanup removes the row
+        // once the presigned URL has expired.
+        // Reuse the percent-encoded pathname from the signed URL so the
+        // stored link matches the one shown right after upload (raw names
+        // with '#', '?', etc. would otherwise break the URL).
+        fileId = await ctx.runMutation(internal.files.saveFile, {
+          url: `${process.env.DESTINATION_URL}${new URL(shortUrl).pathname}`,
           type: args.type,
           size: args.size,
-        })
+        });
+        await ctx.scheduler.runAfter(1200 * 1000, internal.files.deleteIfPending, {
+          fileId
+        });
       }
 
-      return { url: shortUrl };
+      return { url: shortUrl, fileId };
   },
 });
 
@@ -111,11 +167,38 @@ export const saveFile = internalMutation({
   },
   handler: async (ctx, args) => {
     const user = await getCurrentUserOrThrow(ctx);
-    await ctx.db.insert("files", {
+    return ctx.db.insert("files", {
       url: args.url,
       type: args.type,
       size: args.size,
-      userId: user._id
+      userId: user._id,
+      pending: true
     });
   }
 })
+
+export const confirmUpload = mutation({
+  args: {
+    fileId: v.id("files")
+  },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUserOrThrow(ctx);
+    const file = await ctx.db.get(args.fileId);
+    if (!file || file.userId !== user._id) {
+      throw new Error("File not found");
+    }
+    await ctx.db.patch(args.fileId, { pending: false });
+  }
+});
+
+export const deleteIfPending = internalMutation({
+  args: {
+    fileId: v.id("files")
+  },
+  handler: async (ctx, args) => {
+    const file = await ctx.db.get(args.fileId);
+    if (file?.pending) {
+      await ctx.db.delete(args.fileId);
+    }
+  }
+});

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -6,6 +6,65 @@ import { Webhook } from "svix";
 
 const http = httpRouter();
 
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+};
+
+http.route({
+  path: "/getUploadUrl",
+  method: "OPTIONS",
+  handler: httpAction(async () => {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }),
+});
+
+http.route({
+  path: "/getUploadUrl",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    let body;
+    try {
+      body = await request.json();
+    } catch {
+      return jsonResponse({ error: "Invalid JSON body" }, 400);
+    }
+
+    // Rate-limit authenticated users by user id, anonymous users by
+    // client IP — never by a shared bucket.
+    const identity = await ctx.auth.getUserIdentity();
+    const ip =
+      request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+      "unknown";
+    const identifier = identity?.subject ?? `ip:${ip}`;
+
+    try {
+      const result = await ctx.runAction(internal.files.getUploadUrl, {
+        name: String(body.name ?? ""),
+        type: String(body.type ?? ""),
+        size: Number(body.size ?? 0),
+        save: body.save === true,
+        turnstileToken: String(body.turnstileToken ?? ""),
+        identifier,
+      });
+      return jsonResponse(result, 200);
+    } catch (error) {
+      console.error(error);
+      const message =
+        error instanceof Error ? error.message : "Failed to get upload URL";
+      return jsonResponse({ error: message }, 400);
+    }
+  }),
+});
+
+function jsonResponse(body: unknown, status: number) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...corsHeaders },
+  });
+}
+
 http.route({
   path: "/clerk-users-webhook",
   method: "POST",

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -10,6 +10,7 @@ export default defineSchema({
     url: v.string(),
     size: v.number(),
     type: v.string(),
-    userId: v.id("users")
-  })
+    userId: v.id("users"),
+    pending: v.optional(v.boolean())
+  }).index("byUserId", ["userId"])
 });


### PR DESCRIPTION
## What changed

### UX
- Turnstile widget is hidden until the user clicks **Upload**. First click renders the widget; once the challenge is solved the upload starts automatically (no second click). Upload button is now gated on a selected file instead of a token.

### Backend hardening (found during review)
- **Size limit actually enforced**: `Number(process.env.MAX_SIZE) ?? MAX_SIZE` never fell back (`Number(undefined)` is `NaN`, not nullish), so with `MAX_SIZE` unset any size passed. Replaced with a NaN-proof `getMaxUploadSize()` used by both the limit check and the `getMaxSize` query.
- **No dead /files rows**: file rows are inserted as `pending` at presign time and confirmed by a new `confirmUpload` mutation after the PUT succeeds. A scheduled `deleteIfPending` job (20 min, past the 15 min presign expiry) removes rows that never get confirmed. `getFiles` filters out pending rows.
- **Saved links match shown links**: the DB now stores the percent-encoded pathname from the signed URL. Previously raw filenames with `#`/`?` produced broken `/files` links. Existing rows are unaffected (forward-only fix).
- **Per-IP rate limiting for anonymous users**: all logged-out users previously shared one literal `anonymous` bucket. Presigning now goes through a Convex HTTP action (`POST /getUploadUrl`) that keys the limiter on `identity.subject` or the client IP from `x-forwarded-for`. `getUploadUrl` became an `internalAction` so the route cannot be bypassed; the client fetches the route with its Clerk JWT (`template: convex`).
- **Indexed getFiles**: added `byUserId` index on `files` and switched `getFiles` to `withIndex`, removing a full-table scan.
- **Server-side input validation**: filenames are sanitized in the action (path separators and control chars replaced, length capped at 256, `.`/`..` rejected) so names can never escape their random key prefix; `type` length and `size` (positive integer) are validated too. Client-side zod alone was bypassable.

## Notes for reviewers
- `files.getUploadUrl` signature changed (now internal, takes `identifier`); the client calls the new HTTP route on `*.convex.site` derived from `NEXT_PUBLIC_CONVEX_URL` — no new env vars.
- Schema change (`pending` field + `byUserId` index) deploys with the next `convex deploy`.
- One Turnstile solve still maps to one upload; a bot solving N challenges now only burns its own IP bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)