### PR TITLE
Add Glypho public gallery on a subdomain with publish checkbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,25 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Glypho — public gallery subdomain
+
+`/site` hosts **Glypho**, a public masonry collage of images that users opt
+into publishing via the "Add to Glypho" checkbox on the uploader (requires an
+account; the upload is also saved to it).
+
+To serve it on its own subdomain, point the subdomain at the same deployment
+and set:
+
+- `NEXT_PUBLIC_GALLERY_HOST` — hostname of the gallery (e.g. `glypho.0016.cz`).
+  The middleware rewrites requests for this host to `/site`.
+- `NEXT_PUBLIC_GALLERY_URL` — full URL of the gallery (e.g.
+  `https://glypho.0016.cz`), used by the uploader to link to it.
+- `NEXT_PUBLIC_MAIN_SITE_URL` — full URL of the main uploader (e.g.
+  `https://0016.cz`), used by the gallery to link back.
+
+Without these set, the gallery is still reachable at `/site` and links fall
+back to relative paths.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,16 +4,9 @@ import "./globals.css";
 import NoSSRWrapper from "@/app/NoSSRWrapper";
 import { PostHogProvider } from "@/app/providers";
 import { Toaster } from "@/components/ui/sonner";
-import {
-  ClerkProvider,
-  SignInButton,
-  SignedIn,
-  SignedOut,
-  UserButton,
-} from "@clerk/nextjs";
-import { Button } from "@/components/ui/button";
+import { ClerkProvider } from "@clerk/nextjs";
 import ConvexClientProvider from "@/app/ConvexClientProvider";
-import { Navbar } from "@/components/Navbar";
+import { MainHeader } from "@/components/MainHeader";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -49,29 +42,7 @@ export default function RootLayout({
           <PostHogProvider>
             <ClerkProvider>
               <ConvexClientProvider>
-                <header
-                  className={
-                    "flex h-14 items-center justify-between px-2 sm:h-16 sm:px-4"
-                  }
-                >
-                  <Navbar />
-                  <div className="ml-auto flex items-center gap-2 sm:gap-4">
-                    <SignedOut>
-                      <SignInButton>
-                        <Button
-                          className={"text-xs sm:text-sm"}
-                          size={"sm"}
-                          aria-label="Sign in"
-                        >
-                          Sign In
-                        </Button>
-                      </SignInButton>
-                    </SignedOut>
-                    <SignedIn>
-                      <UserButton />
-                    </SignedIn>
-                  </div>
-                </header>
+                <MainHeader />
                 {children}
               </ConvexClientProvider>
             </ClerkProvider>

--- a/app/site/glypho.css
+++ b/app/site/glypho.css
@@ -1,0 +1,390 @@
+/* ============================================================
+   glypho — raw internet-native, brutalist monospace
+   Ported from the Claude Design handoff (Glypho.html).
+   Scoped under .glypho-app so it can't leak into the main app.
+   ============================================================ */
+
+.glypho-app {
+  --mono: var(--font-glypho-mono), "JetBrains Mono", "IBM Plex Mono",
+    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+
+  /* light */
+  --bg: #f4f3ee;
+  --bg-2: #eceae3;
+  --bg-3: #e3e0d6;
+  --fg: #0c0c0c;
+  --fg-2: #3a3a36;
+  --fg-3: #6b6b63;
+  --line: #0c0c0c;
+  --line-soft: #0c0c0c22;
+  --accent: #ff4d2e;
+  --accent-fg: #0c0c0c;
+  --card: #ffffff;
+  --overlay: #0c0c0cee;
+}
+
+.glypho-app.theme-dark {
+  --bg: #0e0e0d;
+  --bg-2: #161614;
+  --bg-3: #1f1f1c;
+  --fg: #f2efe6;
+  --fg-2: #c9c5b7;
+  --fg-3: #8a8679;
+  --line: #f2efe6;
+  --line-soft: #f2efe625;
+  --accent: #ff5a3d;
+  --accent-fg: #0e0e0d;
+  --card: #161614;
+  --overlay: #000000ee;
+}
+
+.glypho-app {
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  transition: background .15s, color .15s;
+}
+
+.glypho-app *, .glypho-app *::before, .glypho-app *::after { box-sizing: border-box; }
+
+.glypho-app a { color: inherit; cursor: pointer; }
+.glypho-app button { font-family: var(--mono); font-size: 13px; cursor: pointer; }
+.glypho-app input { font-family: var(--mono); font-size: 13px; }
+
+.glypho-app ::selection { background: var(--accent); color: #fff; }
+
+/* ============================================================
+   Header
+   ============================================================ */
+.glypho-app .hdr {
+  position: sticky; top: 0; z-index: 40;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 24px;
+  padding: 14px 20px;
+  background: var(--bg);
+  border-bottom: 1.5px solid var(--line);
+}
+.glypho-app .hdr-left { display: flex; align-items: center; gap: 28px; }
+.glypho-app .hdr-nav { display: flex; gap: 14px; }
+.glypho-app .nav-link {
+  font-size: 12px;
+  color: var(--fg-3);
+  text-decoration: none;
+  padding: 4px 0;
+  border-bottom: 1.5px solid transparent;
+  background: transparent;
+  border-top: none; border-left: none; border-right: none;
+}
+.glypho-app .nav-link:hover { color: var(--fg); }
+.glypho-app .nav-link.active { color: var(--fg); border-bottom-color: var(--fg); }
+
+.glypho-app .logo { display: flex; align-items: center; gap: 10px; text-decoration: none; }
+.glypho-app .logo-mark {
+  width: 22px; height: 22px;
+  display: grid; grid-template-columns: 1fr 1fr; grid-template-rows: 1fr 1fr; gap: 2px;
+}
+.glypho-app .logo-sq { background: var(--fg); }
+.glypho-app .logo-sq:nth-child(1) { background: var(--accent); }
+.glypho-app .logo-sq:nth-child(4) { background: var(--accent); }
+.glypho-app .logo-word { font-weight: 700; letter-spacing: -0.02em; font-size: 15px; }
+.glypho-app .logo-tag { color: var(--fg-3); font-size: 11px; }
+
+.glypho-app .hdr-search {
+  display: flex; align-items: center; gap: 8px;
+  padding: 8px 12px;
+  background: var(--bg-2);
+  border: 1.5px solid var(--line);
+  max-width: 520px;
+  margin: 0 auto;
+  width: 100%;
+}
+.glypho-app .hdr-search input {
+  background: transparent; border: none; outline: none; color: var(--fg);
+  flex: 1;
+  min-width: 0;
+}
+.glypho-app .search-prefix { color: var(--accent); font-weight: 700; }
+.glypho-app .search-kbd {
+  padding: 1px 6px;
+  background: var(--bg);
+  border: 1px solid var(--line-soft);
+  font-size: 11px;
+  color: var(--fg-3);
+}
+
+.glypho-app .hdr-right { display: flex; align-items: center; gap: 10px; }
+.glypho-app .hdr-right .btn { height: 34px; }
+
+.glypho-app .btn {
+  font-family: var(--mono);
+  font-size: 12px;
+  padding: 8px 14px;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1.5px solid var(--line);
+  cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  transition: transform .05s, background .1s;
+  text-decoration: none;
+}
+.glypho-app .btn:hover { background: var(--bg-2); }
+.glypho-app .btn:active { transform: translateY(1px); }
+.glypho-app .btn-primary {
+  background: var(--fg);
+  color: var(--bg);
+  border-color: var(--fg);
+}
+.glypho-app .btn-primary:hover { background: var(--accent); border-color: var(--accent); color: var(--accent-fg); }
+.glypho-app .btn-ghost { background: transparent; }
+.glypho-app .btn.small { padding: 6px 10px; font-size: 11px; }
+.glypho-app .btn:disabled { opacity: .45; cursor: not-allowed; }
+.glypho-app .btn-icon { font-weight: 700; font-size: 14px; }
+
+@media (max-width: 820px) {
+  .glypho-app .hdr { grid-template-columns: auto auto; }
+  .glypho-app .hdr-search { display: none; }
+}
+
+/* ============================================================
+   Collage
+   ============================================================ */
+.glypho-app .collage { padding: 16px; }
+
+.glypho-app .layout-masonry {
+  column-count: 6;
+  column-gap: 10px;
+}
+.glypho-app .layout-masonry .tile {
+  break-inside: avoid;
+  margin-bottom: 10px;
+  width: 100%;
+  display: block;
+}
+@media (max-width: 1400px) { .glypho-app .layout-masonry { column-count: 5; } }
+@media (max-width: 1100px) { .glypho-app .layout-masonry { column-count: 4; } }
+@media (max-width: 820px)  { .glypho-app .layout-masonry { column-count: 3; } }
+@media (max-width: 560px)  { .glypho-app .layout-masonry { column-count: 2; } }
+
+.glypho-app .tile {
+  position: relative;
+  overflow: hidden;
+  border: 1.5px solid var(--line);
+  cursor: pointer;
+  background: var(--bg-2);
+  transition: transform .12s ease;
+  animation: glyphoTileIn .35s ease both;
+}
+.glypho-app .tile:hover { transform: translateY(-2px); box-shadow: 4px 4px 0 var(--line); }
+
+@keyframes glyphoTileIn {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.glypho-app .tile-img { width: 100%; height: auto; display: block; }
+
+.glypho-app .tile-badge {
+  position: absolute; top: 6px; left: 6px;
+  background: var(--fg); color: var(--bg);
+  font-size: 9px; font-weight: 700;
+  padding: 2px 5px;
+  letter-spacing: 0.08em;
+}
+.glypho-app .tile-badge.lg { font-size: 11px; padding: 4px 8px; top: 10px; left: 10px; }
+
+.glypho-app .tile-overlay {
+  position: absolute; inset: 0;
+  display: flex; flex-direction: column; justify-content: flex-end;
+  padding: 8px;
+  background: linear-gradient(180deg, transparent 0%, transparent 50%, #000000cc 100%);
+  opacity: 0;
+  transition: opacity .15s;
+  pointer-events: none;
+}
+.glypho-app .tile:hover .tile-overlay { opacity: 1; pointer-events: auto; }
+.glypho-app .tile-bottom { display: flex; justify-content: space-between; align-items: flex-end; gap: 6px; color: #fff; }
+.glypho-app .tile-author {
+  font-size: 11px; opacity: .9;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.glypho-app .tile-actions { display: flex; gap: 4px; }
+.glypho-app .tile-btn {
+  background: rgba(255,255,255,.95);
+  color: #000;
+  border: none;
+  padding: 3px 6px;
+  font-size: 10px;
+  font-family: var(--mono);
+  cursor: pointer;
+}
+.glypho-app .tile-btn:hover { background: var(--accent); color: #fff; }
+
+/* ============================================================
+   Sentinel / Loader / Empty / Footer
+   ============================================================ */
+.glypho-app .sentinel { padding: 30px; text-align: center; }
+.glypho-app .loader {
+  display: inline-flex; align-items: center; gap: 10px;
+  color: var(--fg-3); font-size: 12px;
+  padding: 10px 18px;
+  border: 1.5px solid var(--line-soft);
+}
+.glypho-app .loader-dots { display: inline-flex; gap: 3px; }
+.glypho-app .loader-dots span {
+  width: 6px; height: 6px; background: var(--accent);
+  animation: glyphoDotBounce 1s infinite;
+}
+.glypho-app .loader-dots span:nth-child(2) { animation-delay: .15s; }
+.glypho-app .loader-dots span:nth-child(3) { animation-delay: .3s; }
+@keyframes glyphoDotBounce { 0%, 80%, 100% { opacity: .3; } 40% { opacity: 1; } }
+
+.glypho-app .end-mark { color: var(--fg-3); font-size: 12px; }
+
+.glypho-app .empty {
+  padding: 80px 20px;
+  text-align: center;
+  display: flex; flex-direction: column; align-items: center; gap: 12px;
+}
+.glypho-app .empty-title { font-weight: 700; font-size: 16px; }
+.glypho-app .empty-sub { color: var(--fg-3); font-size: 12px; }
+
+.glypho-app .ftr {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr 1fr 1fr 1.5fr;
+  gap: 24px;
+  padding: 28px 20px;
+  border-top: 1.5px solid var(--line);
+  font-size: 11px;
+  color: var(--fg-3);
+}
+@media (max-width: 820px) { .glypho-app .ftr { grid-template-columns: 1fr 1fr; } }
+.glypho-app .ftr-col a { display: block; color: var(--fg-2); text-decoration: none; padding: 2px 0; }
+.glypho-app .ftr-col a:hover { color: var(--accent); }
+.glypho-app .ftr-h { color: var(--fg); font-weight: 700; margin-bottom: 6px; text-transform: uppercase; letter-spacing: 0.08em; font-size: 10px; }
+.glypho-app .ftr-col.right { text-align: right; display: flex; flex-direction: column; align-items: flex-end; gap: 4px; }
+.glypho-app .status-dot { width: 8px; height: 8px; background: #06d6a0; border-radius: 50%; box-shadow: 0 0 0 3px #06d6a022; }
+
+/* ============================================================
+   Lightbox
+   ============================================================ */
+.glypho-app .lb-backdrop {
+  position: fixed; inset: 0;
+  background: var(--overlay);
+  z-index: 200;
+  display: flex;
+  padding: 30px;
+  animation: glyphoFadeIn .15s;
+}
+@keyframes glyphoFadeIn { from { opacity: 0; } to { opacity: 1; } }
+
+.glypho-app .lb {
+  display: grid;
+  grid-template-columns: 1fr 360px;
+  background: var(--card);
+  border: 1.5px solid var(--line);
+  max-width: 1400px;
+  max-height: calc(100vh - 60px);
+  width: 100%;
+  margin: auto;
+  overflow: hidden;
+  animation: glyphoPopIn .2s;
+}
+@media (max-width: 820px) {
+  .glypho-app .lb { grid-template-columns: 1fr; overflow-y: auto; }
+  .glypho-app .lb-backdrop { padding: 12px; }
+}
+@keyframes glyphoPopIn { from { transform: scale(.98); opacity: 0; } to { transform: scale(1); opacity: 1; } }
+
+.glypho-app .lb-img {
+  position: relative;
+  background: var(--bg-2);
+  max-height: calc(100vh - 60px);
+  overflow: hidden;
+  border-right: 1.5px solid var(--line);
+  display: flex; align-items: center; justify-content: center;
+}
+.glypho-app .lb-img img {
+  max-width: 100%;
+  max-height: calc(100vh - 60px);
+  display: block;
+}
+.glypho-app .lb-side {
+  padding: 18px;
+  overflow-y: auto;
+  max-height: calc(100vh - 60px);
+  display: flex; flex-direction: column; gap: 14px;
+}
+.glypho-app .lb-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 10px; }
+.glypho-app .lb-title { font-weight: 700; font-size: 16px; letter-spacing: -0.01em; word-break: break-all; }
+.glypho-app .lb-close {
+  background: transparent;
+  border: 1.5px solid var(--line);
+  width: 28px; height: 28px;
+  min-width: 28px;
+  font-size: 18px; line-height: 1;
+  color: var(--fg);
+  padding: 0;
+  cursor: pointer;
+}
+.glypho-app .lb-close:hover { background: var(--accent); color: #fff; border-color: var(--accent); }
+.glypho-app .lb-row { display: flex; align-items: center; gap: 10px; }
+.glypho-app .lb-author { font-weight: 700; }
+.glypho-app .lb-sub { color: var(--fg-3); font-size: 11px; }
+.glypho-app .lb-stats {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 1.5px;
+  border: 1.5px solid var(--line);
+  background: var(--line);
+}
+.glypho-app .lb-stats > div {
+  background: var(--card);
+  padding: 10px 12px;
+  display: flex; flex-direction: column;
+  min-width: 0;
+}
+.glypho-app .lb-k { color: var(--fg-3); font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; }
+.glypho-app .lb-v { font-weight: 700; font-size: 15px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+.glypho-app .lb-section-h {
+  font-size: 10px; text-transform: uppercase; letter-spacing: 0.1em;
+  color: var(--fg-3);
+  padding-bottom: 4px;
+  border-bottom: 1.5px solid var(--line-soft);
+}
+.glypho-app .lb-url { display: flex; gap: 6px; }
+.glypho-app .lb-url input {
+  flex: 1;
+  min-width: 0;
+  padding: 8px;
+  background: var(--bg-2);
+  border: 1.5px solid var(--line);
+  color: var(--fg);
+  font-size: 11px;
+}
+.glypho-app .lb-actions { display: flex; gap: 6px; }
+.glypho-app .lb-actions .btn { flex: 1; justify-content: center; }
+.glypho-app .lb-meta-foot {
+  margin-top: auto;
+  display: flex; justify-content: space-between;
+  padding-top: 12px;
+  border-top: 1.5px solid var(--line-soft);
+  color: var(--fg-3);
+  font-size: 10px;
+}
+
+.glypho-app .avatar {
+  width: 34px; height: 34px;
+  border: 1.5px solid var(--line);
+  background: var(--bg-2);
+  padding: 0;
+}
+.glypho-app .avatar.small { width: 28px; height: 28px; }
+.glypho-app .avatar-inner {
+  width: 100%; height: 100%;
+  background: conic-gradient(from 45deg, var(--accent), #7209b7, #06d6a0, var(--accent));
+}

--- a/app/site/layout.tsx
+++ b/app/site/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import { JetBrains_Mono } from "next/font/google";
+import "./glypho.css";
+
+const jetbrainsMono = JetBrains_Mono({
+  variable: "--font-glypho-mono",
+  subsets: ["latin"],
+  weight: ["400", "500", "700"],
+});
+
+export const metadata: Metadata = {
+  title: "glypho — gif + image host",
+  description: "Public gif and image collage, powered by 0016.cz",
+};
+
+export default function GlyphoLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return <div className={jetbrainsMono.variable}>{children}</div>;
+}

--- a/app/site/page.tsx
+++ b/app/site/page.tsx
@@ -1,0 +1,421 @@
+"use client";
+
+import { usePaginatedQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { formatBytes } from "@/lib/utils";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+const PAGE_SIZE = 30;
+
+// The main uploading site. On the gallery subdomain "/" resolves to the
+// gallery itself, so links back home need the absolute URL.
+const MAIN_SITE_URL = process.env.NEXT_PUBLIC_MAIN_SITE_URL ?? "/";
+
+type PublicFile = {
+  _id: string;
+  _creationTime: number;
+  url: string;
+  type: string;
+  size: number;
+  author: string;
+};
+
+function fileName(url: string): string {
+  try {
+    const last = new URL(url).pathname.split("/").pop() ?? "";
+    return decodeURIComponent(last) || "untitled";
+  } catch {
+    return "untitled";
+  }
+}
+
+function postedAgo(creationTime: number): string {
+  const days = Math.floor((Date.now() - creationTime) / 86_400_000);
+  if (days < 1) return "today";
+  return `${days}d ago`;
+}
+
+// Deterministic shuffle so "random" stays stable per visit
+function shuffle<T>(arr: T[], seed: number): T[] {
+  const out = [...arr];
+  let s = seed;
+  for (let i = out.length - 1; i > 0; i--) {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    const j = s % (i + 1);
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+
+export default function GlyphoPage() {
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+  const [nav, setNav] = useState<"feed" | "random">("feed");
+  const [seed, setSeed] = useState(1);
+  const [search, setSearch] = useState("");
+  const [lightboxId, setLightboxId] = useState<string | null>(null);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const {
+    results: files,
+    status,
+    loadMore,
+  } = usePaginatedQuery(
+    api.files.getPublicFiles,
+    {},
+    { initialNumItems: PAGE_SIZE },
+  );
+
+  const visible = useMemo(() => {
+    let list = files as PublicFile[];
+    const q = search.trim().toLowerCase();
+    if (q) {
+      list = list.filter(
+        (f) =>
+          fileName(f.url).toLowerCase().includes(q) ||
+          f.author.toLowerCase().includes(q),
+      );
+    }
+    return nav === "random" ? shuffle(list, seed) : list;
+  }, [files, search, nav, seed]);
+
+  // Infinite scroll
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && status === "CanLoadMore") {
+          loadMore(PAGE_SIZE);
+        }
+      },
+      { rootMargin: "600px" },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [status, loadMore]);
+
+  // "/" focuses search, like the design's kbd hint
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (
+        e.key === "/" &&
+        document.activeElement?.tagName !== "INPUT"
+      ) {
+        e.preventDefault();
+        searchRef.current?.focus();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  const copyLink = async (file: PublicFile) => {
+    await navigator.clipboard.writeText(file.url).catch(() => {});
+    setCopiedId(file._id);
+    setTimeout(() => setCopiedId(null), 1400);
+  };
+
+  const currentFile = lightboxId
+    ? (files as PublicFile[]).find((f) => f._id === lightboxId)
+    : null;
+
+  const isLoading =
+    status === "LoadingFirstPage" || status === "LoadingMore";
+  const isEmpty = status === "Exhausted" && files.length === 0;
+
+  return (
+    <div className={`glypho-app theme-${theme}`}>
+      <header className="hdr">
+        <div className="hdr-left">
+          <a className="logo" href="#" onClick={(e) => e.preventDefault()}>
+            <div className="logo-mark">
+              <div className="logo-sq" />
+              <div className="logo-sq" />
+              <div className="logo-sq" />
+              <div className="logo-sq" />
+            </div>
+            <span className="logo-word">glypho</span>
+            <span className="logo-tag">/gif host</span>
+          </a>
+          <nav className="hdr-nav">
+            <button
+              className={`nav-link ${nav === "feed" ? "active" : ""}`}
+              onClick={() => setNav("feed")}
+            >
+              feed
+            </button>
+            <button
+              className={`nav-link ${nav === "random" ? "active" : ""}`}
+              onClick={() => {
+                setNav("random");
+                setSeed((s) => s + 1);
+              }}
+            >
+              random
+            </button>
+          </nav>
+        </div>
+        <div className="hdr-search">
+          <span className="search-prefix">$</span>
+          <input
+            ref={searchRef}
+            placeholder="search: name, author…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          <span className="search-kbd">/</span>
+        </div>
+        <div className="hdr-right">
+          <button
+            className="btn btn-ghost"
+            onClick={() => setTheme(theme === "light" ? "dark" : "light")}
+            title="toggle theme"
+          >
+            {theme === "light" ? "dark" : "light"}
+          </button>
+          <a className="btn btn-primary" href={MAIN_SITE_URL}>
+            <span className="btn-icon">+</span> upload
+          </a>
+        </div>
+      </header>
+
+      {isEmpty ? (
+        <div className="empty">
+          <div className="empty-title">nothing here yet</div>
+          <div className="empty-sub">
+            be the first — upload an image and check “add to glypho”
+          </div>
+          <a className="btn btn-primary" href={MAIN_SITE_URL}>
+            <span className="btn-icon">+</span> upload
+          </a>
+        </div>
+      ) : (
+        <div className="collage layout-masonry">
+          {visible.map((file) => (
+            <Tile
+              key={file._id}
+              file={file}
+              copied={copiedId === file._id}
+              onClick={() => setLightboxId(file._id)}
+              onCopy={() => copyLink(file)}
+            />
+          ))}
+        </div>
+      )}
+
+      <div ref={sentinelRef} className="sentinel">
+        {isLoading ? (
+          <Loader />
+        ) : status === "Exhausted" && files.length > 0 ? (
+          <div className="end-mark">— end of feed —</div>
+        ) : null}
+      </div>
+
+      <Footer />
+
+      {currentFile && (
+        <Lightbox
+          file={currentFile}
+          copied={copiedId === currentFile._id}
+          onCopy={() => copyLink(currentFile)}
+          onClose={() => setLightboxId(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+function Tile({
+  file,
+  copied,
+  onClick,
+  onCopy,
+}: {
+  file: PublicFile;
+  copied: boolean;
+  onClick: () => void;
+  onCopy: () => void;
+}) {
+  return (
+    <div className="tile" onClick={onClick}>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img className="tile-img" src={file.url} alt={fileName(file.url)} loading="lazy" />
+
+      {file.type === "image/gif" && <div className="tile-badge">GIF</div>}
+
+      <div className="tile-overlay">
+        <div className="tile-bottom">
+          <span className="tile-author">@{file.author}</span>
+          <div className="tile-actions">
+            <button
+              className="tile-btn"
+              onClick={(e) => {
+                e.stopPropagation();
+                onCopy();
+              }}
+              title="copy link"
+            >
+              {copied ? "copied!" : "⌘ copy"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Lightbox({
+  file,
+  copied,
+  onCopy,
+  onClose,
+}: {
+  file: PublicFile;
+  copied: boolean;
+  onCopy: () => void;
+  onClose: () => void;
+}) {
+  const [dims, setDims] = useState<string>("—");
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    document.body.style.overflow = "hidden";
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.body.style.overflow = "";
+    };
+  }, [onClose]);
+
+  return (
+    <div className="lb-backdrop" onClick={onClose}>
+      <div className="lb" onClick={(e) => e.stopPropagation()}>
+        <div className="lb-img">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={file.url}
+            alt={fileName(file.url)}
+            onLoad={(e) => {
+              const img = e.currentTarget;
+              setDims(`${img.naturalWidth}×${img.naturalHeight}`);
+            }}
+          />
+          {file.type === "image/gif" && (
+            <div className="tile-badge lg">GIF · loop</div>
+          )}
+        </div>
+        <aside className="lb-side">
+          <div className="lb-head">
+            <div className="lb-title">{fileName(file.url)}</div>
+            <button className="lb-close" onClick={onClose}>
+              ×
+            </button>
+          </div>
+          <div className="lb-row">
+            <div className="avatar small">
+              <div className="avatar-inner" />
+            </div>
+            <div>
+              <div className="lb-author">@{file.author}</div>
+              <div className="lb-sub">posted {postedAgo(file._creationTime)}</div>
+            </div>
+          </div>
+
+          <div className="lb-stats">
+            <div>
+              <span className="lb-k">size</span>
+              <span className="lb-v">{formatBytes(file.size)}</span>
+            </div>
+            <div>
+              <span className="lb-k">dims</span>
+              <span className="lb-v">{dims}</span>
+            </div>
+            <div>
+              <span className="lb-k">type</span>
+              <span className="lb-v">{file.type.replace("image/", "")}</span>
+            </div>
+            <div>
+              <span className="lb-k">posted</span>
+              <span className="lb-v">
+                {new Date(file._creationTime).toLocaleDateString()}
+              </span>
+            </div>
+          </div>
+
+          <div className="lb-section-h">direct link</div>
+          <div className="lb-url">
+            <input readOnly value={file.url} onFocus={(e) => e.target.select()} />
+            <button className="btn btn-primary small" onClick={onCopy}>
+              {copied ? "copied" : "copy"}
+            </button>
+          </div>
+
+          <div className="lb-actions">
+            <a
+              className="btn btn-ghost"
+              href={file.url}
+              download
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              ⤓ download
+            </a>
+          </div>
+
+          <div className="lb-meta-foot">
+            <span>id: {file._id.slice(0, 8)}</span>
+            <span>hosted by 0016.cz</span>
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function Loader() {
+  return (
+    <div className="loader">
+      <div className="loader-dots">
+        <span></span>
+        <span></span>
+        <span></span>
+      </div>
+      <span>loading more…</span>
+    </div>
+  );
+}
+
+function Footer() {
+  return (
+    <footer className="ftr">
+      <div className="ftr-col">
+        <div className="ftr-h">glypho</div>
+        <div>public image collage</div>
+        <div>part of 0016.cz</div>
+      </div>
+      <div className="ftr-col">
+        <div className="ftr-h">host</div>
+        <a href={MAIN_SITE_URL}>upload</a>
+        <a href={`${MAIN_SITE_URL === "/" ? "" : MAIN_SITE_URL}/files`}>
+          my files
+        </a>
+      </div>
+      <div className="ftr-col">
+        <div className="ftr-h">browse</div>
+        <a href="#" onClick={(e) => { e.preventDefault(); window.scrollTo({ top: 0, behavior: "smooth" }); }}>feed</a>
+      </div>
+      <div className="ftr-col">
+        <div className="ftr-h">about</div>
+        <a href={MAIN_SITE_URL}>0016.cz — file uploader</a>
+      </div>
+      <div className="ftr-col right">
+        <div>status: all systems normal</div>
+        <div className="status-dot" />
+      </div>
+    </footer>
+  );
+}

--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -51,6 +51,7 @@ export function FileUpload() {
   const [convertGif, setConvertGif] = useState(false);
   const [removeExif, setRemoveExif] = useState(false);
   const [saveToAccount, setSaveToAccount] = useState(false);
+  const [addToSite, setAddToSite] = useState(false);
   const [optionsOpen, setOptionsOpen] = useState(false);
   const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
   const [showTurnstile, setShowTurnstile] = useState(false);
@@ -204,11 +205,16 @@ export function FileUpload() {
     uploadingRef.current = true;
     await requestWakeLock();
 
+    // Publishing to the public site implies saving to the account so the
+    // collage can attribute the upload.
+    const publishToSite =
+      addToSite && isAuthenticated && file.type.startsWith("image/");
     const fileData = FileData.parse({
       name: file.name,
       type: file.type,
       size: file.size,
-      save: saveToAccount && isAuthenticated
+      save: (saveToAccount || publishToSite) && isAuthenticated,
+      public: publishToSite
     });
 
     // Presign goes through a Convex HTTP action (not a plain action) so the
@@ -464,10 +470,38 @@ export function FileUpload() {
               <CheckboxLabel
                 id={"account"}
                 text={"Save to account"}
-                checked={saveToAccount}
+                checked={saveToAccount || addToSite}
                 setChecked={setSaveToAccount}
-                disabled={!isAuthenticated}
+                disabled={!isAuthenticated || addToSite}
               />
+              <CheckboxLabel
+                id={"site"}
+                text={"Add to Glypho (public gallery)"}
+                checked={addToSite}
+                setChecked={setAddToSite}
+                disabled={
+                  !isAuthenticated ||
+                  !(
+                    selectedFile?.type.startsWith("image/") ||
+                    (convertGif &&
+                      GIF_CONVERTIBLE_TYPES.has(selectedFile?.type ?? ""))
+                  )
+                }
+              />
+              <p className="text-xs text-muted-foreground">
+                Public images appear on{" "}
+                <a
+                  href={
+                    process.env.NEXT_PUBLIC_GALLERY_URL ?? "/site"
+                  }
+                  className="underline hover:text-foreground"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Glypho
+                </a>
+                , our public image collage. Requires an account.
+              </p>
             </div>
           </div>
         </div>

--- a/components/MainHeader.tsx
+++ b/components/MainHeader.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { SignInButton, SignedIn, SignedOut, UserButton } from "@clerk/nextjs";
+import { Button } from "@/components/ui/button";
+import { Navbar } from "@/components/Navbar";
+
+// Header of the main uploading site. Hidden on the Glypho gallery, which has
+// its own chrome — both when served at /site and on the gallery subdomain
+// (where the middleware rewrite keeps the browser path at "/").
+export function MainHeader() {
+  const pathname = usePathname();
+
+  const galleryHost = process.env.NEXT_PUBLIC_GALLERY_HOST;
+  const onGalleryHost =
+    typeof window !== "undefined" &&
+    !!galleryHost &&
+    window.location.hostname === galleryHost;
+
+  if (pathname.startsWith("/site") || onGalleryHost) return null;
+
+  return (
+    <header
+      className={"flex h-14 items-center justify-between px-2 sm:h-16 sm:px-4"}
+    >
+      <Navbar />
+      <div className="ml-auto flex items-center gap-2 sm:gap-4">
+        <SignedOut>
+          <SignInButton>
+            <Button
+              className={"text-xs sm:text-sm"}
+              size={"sm"}
+              aria-label="Sign in"
+            >
+              Sign In
+            </Button>
+          </SignInButton>
+        </SignedOut>
+        <SignedIn>
+          <UserButton />
+        </SignedIn>
+      </div>
+    </header>
+  );
+}

--- a/convex/files.test.ts
+++ b/convex/files.test.ts
@@ -53,6 +53,7 @@ const validArgs = {
   type: "text/plain",
   size: 1000,
   save: false,
+  public: false,
   turnstileToken: "tok",
   identifier: "ip:1.2.3.4",
 };
@@ -205,6 +206,53 @@ describe("getUploadUrl", () => {
     expect(files[0].url).toBe(
       `${process.env.DESTINATION_URL}${new URL(url).pathname}`
     );
+  });
+});
+
+describe("getPublicFiles", () => {
+  test("rejects publishing without saving to account", async () => {
+    const t = convexTest(schema, modules);
+    await createUser(t);
+    const asUser = t.withIdentity(identity);
+    await expect(
+      asUser.action(internal.files.getUploadUrl, {
+        ...validArgs,
+        save: false,
+        public: true,
+      })
+    ).rejects.toThrow("Cannot publish to the site without saving to account");
+  });
+
+  test("shows only confirmed public files with author names", async () => {
+    const t = convexTest(schema, modules);
+    await createUser(t);
+    const asUser = t.withIdentity(identity);
+
+    const publicId = await asUser.mutation(internal.files.saveFile, {
+      url: "https://files.test/abc/public.gif",
+      type: "image/gif",
+      size: 1000,
+      public: true,
+    });
+    // Private file — must never appear in the public feed
+    const privateId = await asUser.mutation(internal.files.saveFile, {
+      url: "https://files.test/abc/private.png",
+      type: "image/png",
+      size: 1000,
+    });
+    await asUser.mutation(api.files.confirmUpload, { fileId: privateId });
+
+    // Still pending — hidden from the public feed
+    expect((await t.query(api.files.getPublicFiles, paginate)).page).toEqual(
+      []
+    );
+
+    await asUser.mutation(api.files.confirmUpload, { fileId: publicId });
+
+    const page = (await t.query(api.files.getPublicFiles, paginate)).page;
+    expect(page).toHaveLength(1);
+    expect(page[0].url).toBe("https://files.test/abc/public.gif");
+    expect(page[0].author).toBe("Test User");
   });
 });
 

--- a/convex/files.ts
+++ b/convex/files.ts
@@ -70,6 +70,7 @@ export const getUploadUrl = internalAction({
     type: v.string(),
     size: v.number(),
     save: v.boolean(),
+    public: v.boolean(),
     turnstileToken: v.string(),
     identifier: v.string(),
   },
@@ -85,6 +86,13 @@ export const getUploadUrl = internalAction({
     const identity = await ctx.auth.getUserIdentity();
     if (!identity && args.save) {
       throw new Error("Saving a file to account without an account");
+    }
+
+    // Publishing to the public collage requires an account (author
+    // attribution) and implies saving the file to that account.
+    const makePublic = args.public && args.save;
+    if (args.public && !args.save) {
+      throw new Error("Cannot publish to the site without saving to account");
     }
 
     const isValidToken = await verifyTurnstileToken(args.turnstileToken);
@@ -137,6 +145,7 @@ export const getUploadUrl = internalAction({
           url: `${process.env.DESTINATION_URL}${new URL(shortUrl).pathname}`,
           type: args.type,
           size: args.size,
+          public: makePublic,
         });
         await ctx.scheduler.runAfter(1200 * 1000, internal.files.deleteIfPending, {
           fileId
@@ -152,6 +161,7 @@ export const saveFile = internalMutation({
     url: v.string(),
     type: v.string(),
     size: v.number(),
+    public: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const user = await getCurrentUserOrThrow(ctx);
@@ -160,7 +170,8 @@ export const saveFile = internalMutation({
       type: args.type,
       size: args.size,
       userId: user._id,
-      pending: true
+      pending: true,
+      public: args.public === true
     });
   }
 })
@@ -176,6 +187,36 @@ export const confirmUpload = mutation({
       throw new Error("File not found");
     }
     await ctx.db.patch(args.fileId, { pending: false });
+  }
+});
+
+// Public collage feed (Glypho). No auth — only rows explicitly published
+// with the "add to site" checkbox, and only confirmed (non-pending) uploads.
+export const getPublicFiles = query({
+  args: { paginationOpts: paginationOptsValidator },
+  handler: async (ctx, args) => {
+    const result = await ctx.db
+      .query("files")
+      .withIndex("byPublic", q => q.eq("public", true))
+      .filter(row => row.neq(row.field("pending"), true))
+      .order("desc")
+      .paginate(args.paginationOpts);
+
+    const page = await Promise.all(
+      result.page.map(async (file) => {
+        const author = await ctx.db.get(file.userId);
+        return {
+          _id: file._id,
+          _creationTime: file._creationTime,
+          url: file.url,
+          type: file.type,
+          size: file.size,
+          author: author?.name ?? "anonymous",
+        };
+      })
+    );
+
+    return { ...result, page };
   }
 });
 

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -45,6 +45,7 @@ http.route({
         type: String(body.type ?? ""),
         size: Number(body.size ?? 0),
         save: body.save === true,
+        public: body.public === true,
         turnstileToken: String(body.turnstileToken ?? ""),
         identifier,
       });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -11,8 +11,12 @@ export default defineSchema({
     size: v.number(),
     type: v.string(),
     userId: v.id("users"),
-    pending: v.optional(v.boolean())
-  }).index("byUserId", ["userId"]),
+    pending: v.optional(v.boolean()),
+    // When true the file is published to the public collage site (Glypho).
+    public: v.optional(v.boolean())
+  })
+    .index("byUserId", ["userId"])
+    .index("byPublic", ["public"]),
   links: defineTable({
     slug: v.string(),
     url: v.string()

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -43,6 +43,7 @@ describe("FileData schema", () => {
       type: "text/plain",
       size: 123,
       save: false,
+      public: false,
     });
     expect(parsed.success).toBe(true);
   });

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -10,7 +10,8 @@ export const FileData = z.object({
   name: z.string().max(256),
   type: z.string().max(256),
   size: z.number(),
-  save: z.boolean()
+  save: z.boolean(),
+  public: z.boolean()
 });
 
 export const Link = z.object({

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,6 +1,20 @@
 import { clerkMiddleware } from '@clerk/nextjs/server';
+import { NextResponse } from 'next/server';
 
-export default clerkMiddleware();
+// Requests for the gallery subdomain (e.g. glypho.0016.cz) are rewritten to
+// the /site route group, which hosts the public Glypho collage.
+export default clerkMiddleware((auth, req) => {
+  const galleryHost = process.env.NEXT_PUBLIC_GALLERY_HOST;
+  const host = req.headers.get('host')?.split(':')[0];
+
+  if (galleryHost && host === galleryHost) {
+    const url = req.nextUrl.clone();
+    if (!url.pathname.startsWith('/site')) {
+      url.pathname = `/site${url.pathname === '/' ? '' : url.pathname}`;
+      return NextResponse.rewrite(url);
+    }
+  }
+});
 
 export const config = {
   matcher: [


### PR DESCRIPTION
## What

Adds **Glypho** — a public image collage gallery — served on a subdomain of the main uploader, plus an "Add to Glypho" publish checkbox on the upload page.

Implements the Claude Design handoff (`Glypho.html`): a raw, internet-native brutalist monospace masonry collage with a lightbox detail view. The prototype's procedural placeholder tiles are replaced by real uploaded images; design-tool scaffolding (tweaks panel, mock sign-in/upload modals) is dropped in favor of the app's real auth + upload flow.

## Changes

- **Gallery page** — `app/site/page.tsx` (+ `glypho.css`, `layout.tsx`): masonry collage (6→2 responsive columns), GIF badges, hover overlay with copy-link, lightbox with stats / direct-link / download, infinite scroll, feed/random nav, `/` search shortcut, light/dark toggle. CSS scoped under `.glypho-app` so it can't bleed into the main app.
- **Subdomain** — `proxy.ts` middleware rewrites requests for `NEXT_PUBLIC_GALLERY_HOST` to `/site`. `components/MainHeader.tsx` hides the uploader chrome on the gallery. Cross-links both ways (gallery → uploader, uploader checkbox → gallery).
- **Publish flow** — `files` table gets a `public` flag + `byPublic` index; new unauthenticated `getPublicFiles` paginated query (joins author name); `public` threaded through `getUploadUrl` → `saveFile`. Publishing requires an account and implies "save to account" (for attribution); server rejects publish-without-save. Pending uploads stay hidden until confirmed.
- **Upload UI** — `FileUpload.tsx` gains the "Add to Glypho (public gallery)" checkbox (image files only) + link to the gallery.

## Reviewer notes

- New env vars (all `NEXT_PUBLIC_*`, optional with fallbacks): `NEXT_PUBLIC_GALLERY_HOST` (middleware rewrite trigger), `NEXT_PUBLIC_GALLERY_URL`, `NEXT_PUBLIC_MAIN_SITE_URL`. Without them the gallery still works at `/site` with relative links. Documented in README.
- Schema change deploys via `convex deploy`; existing rows lack `public` so default to private.
- Verified: `next build` (route `/site` + Proxy middleware present), `tsc --noEmit`, 42 vitest tests (incl. new `getPublicFiles` coverage), eslint (0 errors in new files). Gallery UI driven in Chrome against a mock-data harness — masonry, hover, lightbox, dark theme, responsive columns confirmed against the design.
- Subdomain needs to be added as a domain on the Vercel project pointing at the same deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
