### PR TITLE
Add delete button to files list

### DIFF
--- a/app/(user)/files/page.tsx
+++ b/app/(user)/files/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useConvexAuth, usePaginatedQuery } from "convex/react";
+import { useConvexAuth, useMutation, usePaginatedQuery } from "convex/react";
 import { useRouter } from "next/navigation";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { api } from "@/convex/_generated/api";
 import { ColumnDef, getCoreRowModel } from "@tanstack/table-core";
 import { Doc } from "@/convex/_generated/dataModel";
@@ -18,6 +20,37 @@ import {
 import Link from "next/link";
 import { formatBytes } from "@/lib/utils";
 import { toast } from "sonner";
+
+function DeleteButton({ file }: { file: Doc<"files"> }) {
+  const deleteFile = useMutation(api.files.deleteFile);
+  const [deleting, setDeleting] = useState(false);
+
+  const onDelete = async () => {
+    if (!window.confirm("Delete this file? This cannot be undone.")) return;
+    setDeleting(true);
+    try {
+      await deleteFile({ fileId: file._id });
+      toast.success("File deleted");
+    } catch {
+      toast.error("Failed to delete file");
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={onDelete}
+      disabled={deleting}
+      aria-label="Delete file"
+      className="text-muted-foreground hover:text-destructive"
+    >
+      <Trash2 />
+    </Button>
+  );
+}
 
 const columns: ColumnDef<Doc<"files">>[] = [
   {
@@ -69,6 +102,17 @@ const columns: ColumnDef<Doc<"files">>[] = [
       );
     },
   },
+  {
+    id: "actions",
+    header: "",
+    cell: ({ row }) => {
+      return (
+        <div className="flex justify-end">
+          <DeleteButton file={row.original} />
+        </div>
+      );
+    },
+  },
 ];
 
 // Mobile card component for each file
@@ -81,14 +125,17 @@ function FileCard({ file }: { file: Doc<"files"> }) {
   return (
     <div className="border-b border-border py-4 last:border-b-0">
       <div className="flex flex-col gap-2">
-        <Link
-          href={file.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="break-all text-base font-medium leading-tight hover:underline"
-        >
-          {file.url.split("/").pop() || file.url}
-        </Link>
+        <div className="flex items-start justify-between gap-2">
+          <Link
+            href={file.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="break-all text-base font-medium leading-tight hover:underline"
+          >
+            {file.url.split("/").pop() || file.url}
+          </Link>
+          <DeleteButton file={file} />
+        </div>
         <p
           className="cursor-pointer break-all text-sm text-muted-foreground hover:underline"
           onClick={copyUrl}

--- a/convex/files.test.ts
+++ b/convex/files.test.ts
@@ -306,6 +306,56 @@ describe("deleteIfPending", () => {
   });
 });
 
+describe("deleteFile", () => {
+  test("removes the owner's file from their list", async () => {
+    const t = convexTest(schema, modules);
+    await createUser(t);
+    const asUser = t.withIdentity(identity);
+
+    const fileId = await asUser.mutation(internal.files.saveFile, {
+      url: "https://files.test/abc/test.txt",
+      type: "text/plain",
+      size: 1000,
+    });
+    await asUser.mutation(api.files.confirmUpload, { fileId });
+
+    expect((await asUser.query(api.files.getFiles, paginate)).page).toHaveLength(
+      1
+    );
+
+    await asUser.mutation(api.files.deleteFile, { fileId });
+
+    expect((await asUser.query(api.files.getFiles, paginate)).page).toEqual([]);
+  });
+
+  test("rejects deleting someone else's file", async () => {
+    const t = convexTest(schema, modules);
+    await createUser(t);
+    const asUser = t.withIdentity(identity);
+
+    const fileId = await asUser.mutation(internal.files.saveFile, {
+      url: "https://files.test/abc/test.txt",
+      type: "text/plain",
+      size: 1000,
+    });
+
+    await t.mutation(internal.users.upsertFromClerk, {
+      data: { id: "clerk_user_2", first_name: "Other", last_name: "User" } as UserJSON,
+    });
+    const asOther = t.withIdentity({ subject: "clerk_user_2" });
+
+    await expect(
+      asOther.mutation(api.files.deleteFile, { fileId })
+    ).rejects.toThrow("File not found");
+
+    // Untouched for the owner
+    await asUser.mutation(api.files.confirmUpload, { fileId });
+    expect((await asUser.query(api.files.getFiles, paginate)).page).toHaveLength(
+      1
+    );
+  });
+});
+
 describe("/getUploadUrl http route", () => {
   test("returns 400 on invalid JSON body", async () => {
     const t = convexTest(schema, modules);

--- a/convex/files.ts
+++ b/convex/files.ts
@@ -1,7 +1,7 @@
 import { internalAction, internalMutation, mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import { paginationOptsValidator } from "convex/server";
-import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import { S3Client, PutObjectCommand, DeleteObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { internal } from "@/convex/_generated/api";
 import { getCurrentUser, getCurrentUserOrThrow } from "@/convex/users";
@@ -217,6 +217,56 @@ export const getPublicFiles = query({
     );
 
     return { ...result, page };
+  }
+});
+
+export const deleteFile = mutation({
+  args: {
+    fileId: v.id("files")
+  },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUserOrThrow(ctx);
+    const file = await ctx.db.get(args.fileId);
+    // Owner check — a user can only delete their own rows. Mirror the
+    // "File not found" wording so we don't leak whether the id exists.
+    if (!file || file.userId !== user._id) {
+      throw new Error("File not found");
+    }
+    await ctx.db.delete(args.fileId);
+    // Drop the row immediately; reap the S3 object in a follow-up action
+    // (mutations can't run the S3 client). Orphaned objects are harmless if
+    // this fails.
+    await ctx.scheduler.runAfter(0, internal.files.deleteFromS3, {
+      url: file.url
+    });
+  }
+});
+
+export const deleteFromS3 = internalAction({
+  args: {
+    url: v.string()
+  },
+  handler: async (_ctx, args) => {
+    // Stored url is `${DESTINATION_URL}${pathname}`; the S3 key is that
+    // pathname without its leading slash.
+    const key = new URL(args.url).pathname.replace(/^\/+/, "");
+    if (!key) return;
+
+    const s3Client = new S3Client({
+      region: process.env.S3_REGION,
+      endpoint: process.env.S3_ENDPOINT,
+      credentials: {
+        accessKeyId: process.env.S3_ACCESS_KEY ?? "",
+        secretAccessKey: process.env.S3_SECRET_KEY ?? ""
+      }
+    });
+
+    await s3Client.send(
+      new DeleteObjectCommand({
+        Bucket: process.env.S3_BUCKET,
+        Key: key
+      })
+    );
   }
 });
 


### PR DESCRIPTION
Add a per-row delete control to the authenticated files list so users can remove their own uploads. The button appears in both the desktop table (actions column) and the mobile card layout; the whole page is already gated behind auth, so it only renders for logged-in users.

- deleteFile mutation: owner-checked row delete, schedules S3 cleanup
- deleteFromS3 internalAction: removes the object, orphan-safe on failure
- DeleteButton: confirm prompt, toast feedback, disabled while deleting