### PR TITLE
Add unlimited upload size role via Clerk public metadata

### DIFF
--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -530,7 +530,9 @@ export function FileUpload() {
         Upload
       </Button>
       <span className={"text-sm text-secondary-foreground"}>
-        Max {formatBytes(getMaxSize ?? 250000000)} file size
+        {getMaxSize === null
+          ? "No file size limit"
+          : `Max ${formatBytes(getMaxSize ?? 250000000)} file size`}
       </span>
     </div>
   );

--- a/convex/files.test.ts
+++ b/convex/files.test.ts
@@ -38,12 +38,16 @@ function stubNetwork({ turnstileOk }: { turnstileOk: boolean }) {
   );
 }
 
-async function createUser(t: ReturnType<typeof convexTest>) {
+async function createUser(
+  t: ReturnType<typeof convexTest>,
+  publicMetadata?: Record<string, unknown>
+) {
   await t.mutation(internal.users.upsertFromClerk, {
     data: {
       id: identity.subject,
       first_name: "Test",
       last_name: "User",
+      public_metadata: publicMetadata,
     } as UserJSON,
   });
 }
@@ -73,6 +77,20 @@ describe("getMaxSize", () => {
     const t = convexTest(schema, modules);
     expect(await t.query(api.files.getMaxSize, {})).toBe(1234);
     vi.stubEnv("MAX_SIZE", "");
+  });
+
+  test("returns null for users with unlimited uploads", async () => {
+    const t = convexTest(schema, modules);
+    await createUser(t, { unlimitedUploads: true });
+    const asUser = t.withIdentity(identity);
+    expect(await asUser.query(api.files.getMaxSize, {})).toBeNull();
+  });
+
+  test("returns the limit for users without the flag", async () => {
+    const t = convexTest(schema, modules);
+    await createUser(t);
+    const asUser = t.withIdentity(identity);
+    expect(await asUser.query(api.files.getMaxSize, {})).toBe(250000000);
   });
 });
 
@@ -155,6 +173,33 @@ describe("getUploadUrl", () => {
         size: 250000001,
       })
     ).rejects.toThrow("File is too big");
+  });
+
+  test("rejects oversized files for signed-in users without the flag", async () => {
+    const t = convexTest(schema, modules);
+    await createUser(t);
+    stubNetwork({ turnstileOk: true });
+    const asUser = t.withIdentity(identity);
+
+    await expect(
+      asUser.action(internal.files.getUploadUrl, {
+        ...validArgs,
+        size: 250000001,
+      })
+    ).rejects.toThrow("File is too big");
+  });
+
+  test("allows oversized files for users with unlimited uploads", async () => {
+    const t = convexTest(schema, modules);
+    await createUser(t, { unlimitedUploads: true });
+    stubNetwork({ turnstileOk: true });
+    const asUser = t.withIdentity(identity);
+
+    const { url } = await asUser.action(internal.files.getUploadUrl, {
+      ...validArgs,
+      size: 250000001,
+    });
+    expect(new URL(url).searchParams.get("X-Amz-Signature")).toBeTruthy();
   });
 
   test("returns a presigned url and no fileId for anonymous uploads", async () => {

--- a/convex/files.ts
+++ b/convex/files.ts
@@ -3,7 +3,7 @@ import { v } from "convex/values";
 import { paginationOptsValidator } from "convex/server";
 import { S3Client, PutObjectCommand, DeleteObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import { internal } from "@/convex/_generated/api";
+import { api, internal } from "@/convex/_generated/api";
 import { getCurrentUser, getCurrentUserOrThrow } from "@/convex/users";
 import { Id } from "./_generated/dataModel";
 import { uploadRatelimit, verifyTurnstileToken } from "@/convex/ratelimit";
@@ -38,9 +38,15 @@ function getMaxUploadSize() {
   return Number.isFinite(fromEnv) && fromEnv > 0 ? fromEnv : DEFAULT_MAX_SIZE;
 }
 
+// Returns null when the current user has no upload size limit
+// (Clerk publicMetadata.unlimitedUploads, synced to the users table).
 export const getMaxSize = query({
   args: {},
-  handler: () => {
+  handler: async (ctx) => {
+    const user = await getCurrentUser(ctx);
+    if (user?.unlimitedUploads) {
+      return null;
+    }
     return getMaxUploadSize();
   }
 });
@@ -110,7 +116,12 @@ export const getUploadUrl = internalAction({
     }
 
     if (args.size > getMaxUploadSize()) {
-      throw new Error("File is too big");
+      // The unlimitedUploads flag lives on the Convex user row (synced from
+      // Clerk publicMetadata), so look it up only when the limit is exceeded.
+      const user = identity ? await ctx.runQuery(api.users.current, {}) : null;
+      if (!user?.unlimitedUploads) {
+        throw new Error("File is too big");
+      }
     }
 
       const s3Client = new S3Client({

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -4,7 +4,10 @@ import { v } from "convex/values";
 export default defineSchema({
   users: defineTable({
     name: v.string(),
-    externalId: v.string()
+    externalId: v.string(),
+    // Synced from Clerk publicMetadata.unlimitedUploads via the users webhook.
+    // When true, the per-file upload size limit does not apply.
+    unlimitedUploads: v.optional(v.boolean())
   }).index("byExternalId", ["externalId"]),
   files: defineTable({
     url: v.string(),

--- a/convex/users.test.ts
+++ b/convex/users.test.ts
@@ -51,6 +51,26 @@ describe("upsertFromClerk", () => {
       .query(api.users.current, {});
     expect(user?.name).toBe("Renamed User");
   });
+
+  test("syncs unlimitedUploads from Clerk public metadata", async () => {
+    const t = convexTest(schema, modules);
+    await t.mutation(internal.users.upsertFromClerk, {
+      data: clerkUser({
+        public_metadata: { unlimitedUploads: true },
+      } as Partial<UserJSON>),
+    });
+
+    const asUser = t.withIdentity({ subject: "clerk_user_1" });
+    expect((await asUser.query(api.users.current, {}))?.unlimitedUploads).toBe(
+      true
+    );
+
+    // Removing the flag in Clerk revokes it here on the next webhook
+    await t.mutation(internal.users.upsertFromClerk, { data: clerkUser() });
+    expect((await asUser.query(api.users.current, {}))?.unlimitedUploads).toBe(
+      false
+    );
+  });
 });
 
 describe("deleteFromClerk", () => {

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -17,6 +17,7 @@ export const upsertFromClerk = internalMutation({
     const userAttributes = {
       name: `${data.first_name} ${data.last_name}`,
       externalId: data.id,
+      unlimitedUploads: data.public_metadata?.unlimitedUploads === true,
     };
 
     const user = await userByExternalId(ctx, data.id);


### PR DESCRIPTION
## What

Adds an "unlimited uploads" role: users with `publicMetadata.unlimitedUploads: true` in Clerk bypass the per-file upload size limit.

## How

- **Grant/revoke**: set `{"unlimitedUploads": true}` in the user's public metadata in the Clerk dashboard. The existing `user.updated` webhook syncs the flag to the Convex `users` table (removing it revokes on the next webhook).
- **Enforcement** (`convex/files.ts`): `getUploadUrl` looks up the current user only when the requested size exceeds the limit, so normal uploads pay no extra query. Anonymous users are always limited.
- **UI**: `getMaxSize` now returns `null` for unlimited users; the uploader shows "No file size limit" instead of "Max 250 MB".

## Notes for review

- Chose Clerk public metadata over Clerk organizations/roles: per-user toggle in the dashboard, no org setup, and the webhook sync already existed.
- Public metadata is visible to the client, but the flag only reveals a limit tier — the server check is authoritative.
- Tests: metadata sync + revoke, oversized rejected for anonymous and unflagged signed-in users, allowed for flagged users, `getMaxSize` returns `null`/limit per user. 49 tests pass, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
